### PR TITLE
DM-9224: Add purge_key function for Fastly

### DIFF
--- a/ltdconveyor/__init__.py
+++ b/ltdconveyor/__init__.py
@@ -3,7 +3,7 @@ import pkg_resources
 from .s3upload import upload_dir, upload_file, upload_object, ObjectManager  # noqa: F401,E501
 from .s3delete import delete_dir  # noqa: F401
 from .s3copy import copy_dir  # noqa: F401
-from .exceptions import S3Error  # noqa: F401
+from .exceptions import S3Error, FastlyError, ConveyorError  # noqa: F401
 
 
 __version__ = pkg_resources.get_distribution("ltd-conveyor").version

--- a/ltdconveyor/__init__.py
+++ b/ltdconveyor/__init__.py
@@ -3,6 +3,7 @@ import pkg_resources
 from .s3upload import upload_dir, upload_file, upload_object, ObjectManager  # noqa: F401,E501
 from .s3delete import delete_dir  # noqa: F401
 from .s3copy import copy_dir  # noqa: F401
+from .fastly import purge_key  # noqa: F401
 from .exceptions import S3Error, FastlyError, ConveyorError  # noqa: F401
 
 

--- a/ltdconveyor/exceptions.py
+++ b/ltdconveyor/exceptions.py
@@ -1,6 +1,16 @@
 """Exception library."""
 
 
-class S3Error(Exception):
-    """Errors related to AWS S3 usage."""
+class ConveyorError(Exception):
+    """Generic base exception class for ltdconveyor."""
+    pass
+
+
+class S3Error(ConveyorError):
+    """Error related to AWS S3 usage."""
+    pass
+
+
+class FastlyError(ConveyorError):
+    """Error related to Fastly API usage."""
     pass

--- a/ltdconveyor/fastly.py
+++ b/ltdconveyor/fastly.py
@@ -1,0 +1,50 @@
+"""Management of Fastly CDN caching.
+
+See https://docs.fastly.com/api for background.
+"""
+
+import logging
+import requests
+
+from .exceptions import FastlyError
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def purge_key(surrogate_key, service_id, api_key):
+    """Instant purge URLs with a given surrogate key from the Fastly caches.
+
+    Parameters
+    ----------
+    surrogate_key : `str`
+        Surrogate key header (``x-amz-meta-surrogate-key``) value of objects
+        to purge from the Fastly cache.
+    service_id : `str`
+        Fastly service ID.
+    api_key : `str`
+        Fastly API key.
+
+    Raises
+    ------
+    FastlyError
+       Error with the Fastly API usage.
+
+    Notes
+    -----
+    This function uses Fastly's ``/service/{service}/purge/{key}`` endpoint.
+
+    See the `Fastly Purge documentation <http://ls.st/jxg>`_ for more
+    information.
+    """
+    api_root = 'https://api.fastly.com'
+    path = '/service/{service}/purge/{surrogate_key}'.format(
+        service=service_id,
+        surrogate_key=surrogate_key)
+    logger.info('Fastly purge {0}'.format(path))
+    r = requests.post(api_root + path,
+                      headers={'Fastly-Key': api_key,
+                               'Accept': 'application/json'})
+    if r.status_code != 200:
+        raise FastlyError(r.json)

--- a/ltdconveyor/fastly.py
+++ b/ltdconveyor/fastly.py
@@ -34,9 +34,11 @@ def purge_key(surrogate_key, service_id, api_key):
     Notes
     -----
     This function uses Fastly's ``/service/{service}/purge/{key}`` endpoint.
-
     See the `Fastly Purge documentation <http://ls.st/jxg>`_ for more
     information.
+
+    For other Fastly APIs, consider using `fastly-py
+    <https://github.com/fastly/fastly-py>`_.
     """
     api_root = 'https://api.fastly.com'
     path = '/service/{service}/purge/{surrogate_key}'.format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 -e .
 
 # Development dependencies
-requests==2.12.4
+responses==0.5.1
 pytest==3.0.5
 pytest-cov==2.4.0
 pytest-flake8==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-conveyor'
-version = '0.1.0'
+version = '0.2.0'
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     packages=find_packages(exclude=['docs', 'tests*', 'data']),
     install_requires=['future>=0.16.0',
                       'boto3>=1.4.4',
-                      'backports.tempfile==1.0rc1']
+                      'backports.tempfile==1.0rc1',
+                      'requests>=2.12.4']
     # package_data={},
     # entry_points={}
 )

--- a/tests/test_fastly.py
+++ b/tests/test_fastly.py
@@ -1,0 +1,46 @@
+"""Tests for `ltdconveyor.fastly`."""
+
+import uuid
+import pytest
+import responses
+
+from ltdconveyor import purge_key, FastlyError
+
+
+@responses.activate
+def test_purge_key():
+    service_id = 'SU1Z0isxPaozGVKXdv0eY'
+    api_key = 'd3cafb4dde4dbeef'
+    surrogate_key = uuid.uuid4().hex
+
+    url = 'https://api.fastly.com/service/{0}/purge/{1}'.format(
+        service_id, surrogate_key)
+
+    # Mock the API call and response
+    responses.add(responses.POST, url, status=200)
+
+    purge_key(surrogate_key, service_id, api_key)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == url
+    assert responses.calls[0].request.headers['Fastly-Key'] == api_key
+    assert responses.calls[0].request.headers['Accept'] == 'application/json'
+
+
+@responses.activate
+def test_purge_key_fail():
+    service_id = 'SU1Z0isxPaozGVKXdv0eY'
+    api_key = 'd3cafb4dde4dbeef'
+    surrogate_key = uuid.uuid4().hex
+
+    url = 'https://api.fastly.com/service/{0}/purge/{1}'.format(
+        service_id, surrogate_key)
+
+    # Mock the API call and response
+    responses.add(responses.POST, url, status=404)
+
+    with pytest.raises(FastlyError):
+        purge_key(surrogate_key, service_id, api_key)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == url
+    assert responses.calls[0].request.headers['Fastly-Key'] == api_key
+    assert responses.calls[0].request.headers['Accept'] == 'application/json'


### PR DESCRIPTION
This function allows applications to purge objects from the Fastly cache (especially if replacement objects have been uploaded). This functionality is ported from https://github.com/lsst-sqre/ltd-keeper

Draft docs: https://ltd-conveyor.lsst.io/v/DM-9224/py-api/ltdconveyor.purge_key.html#ltdconveyor.purge_key