### PR TITLE
DM-9023: Better support for uploading str objects and directories

### DIFF
--- a/ltdconveyor/__init__.py
+++ b/ltdconveyor/__init__.py
@@ -1,6 +1,8 @@
 import pkg_resources
 
-from .s3upload import upload_dir, upload_file, upload_object, ObjectManager  # noqa: F401,E501
+from .s3upload import (upload_dir, upload_file, upload_object,  # noqa: F401
+                       create_dir_redirect_object,  # noqa: F401
+                       ObjectManager)  # noqa: F401
 from .s3delete import delete_dir  # noqa: F401
 from .s3copy import copy_dir  # noqa: F401
 from .fastly import purge_key  # noqa: F401

--- a/ltdconveyor/s3upload.py
+++ b/ltdconveyor/s3upload.py
@@ -398,6 +398,10 @@ class ObjectManager(object):
 
         if '.' in dirnames:
             dirnames.remove('.')
+
+        if '..' in dirnames:
+            dirnames.remove('..')
+
         return dirnames
 
     def _create_prefix(self, dirname):

--- a/ltdconveyor/s3upload.py
+++ b/ltdconveyor/s3upload.py
@@ -213,7 +213,8 @@ def upload_file(local_path, bucket_path, bucket,
 
 
 def upload_object(bucket_path, bucket, content='',
-                  metadata=None, acl=None, cache_control=None):
+                  metadata=None, acl=None, cache_control=None,
+                  content_type=None):
     """Upload an arbitrary object to an S3 bucket.
 
     Parameters
@@ -233,6 +234,10 @@ def upload_object(bucket_path, bucket, content='',
         https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
     cache_control : `str`, optional
         The cache-control header value. For example, ``'max-age=31536000'``.
+    content_type : `str`, optional
+        The object's content type (such as ``text/html``). If left unset,
+        no MIME type is passed to boto3 (which defaults to
+        ``binary/octet-stream``).
     """
     obj = bucket.Object(bucket_path)
 
@@ -244,6 +249,8 @@ def upload_object(bucket_path, bucket, content='',
         args['ACL'] = acl
     if cache_control is not None:
         args['CacheControl'] = cache_control
+    if content_type is not None:
+        args['ContentType'] = content_type
 
     obj.put(Body=content, **args)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-conveyor'
-version = '0.2.0'
+version = '0.3.0rc0'
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-conveyor'
-version = '0.3.0rc0'
+version = '0.3.0rc1'
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-conveyor'
-version = '0.3.0rc2'
+version = '0.3.0'
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-conveyor'
-version = '0.3.0rc1'
+version = '0.3.0rc2'
 
 
 def read(filename):


### PR DESCRIPTION
- `upload_object()` lets a user specify the content-type header. Used by LTD Dasher that uploads rendered templates with this function.
- Adds `create_dir_redirect_object()` to manually create 'directory redirect objects' (objects in S3 named after a directory that instruct Fastly to redirect a browser to `dirname/index.html`). Again, Dasher needs this.
- Fixes an issue with `upload_dir()` that came up during Dasher testing.

Draft docs: https://ltd-conveyor.lsst.io/v/DM-9023