### PR TITLE
DM-16061: Fix issue when deleting a prefix with no objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,14 +2,22 @@
 Change log
 ##########
 
+0.4.2 (2018-10-09)
+==================
+
+Fixed
+-----
+
+- Fixed a bug where ``ltdconveyor.s3.delete_dir``, since 0.4.1, would raise a ``TypeError`` while deleting an empty directory (no objects in the S3 prefix).
+
 0.4.1 (2018-10-08)
 ==================
 
 Fixed
 -----
 
-- Fixed a bug where ``ltdconveoyr.s3.delete_dir`` would fail if there are more than 1000 objects under a path prefix that is being deleted.
-- Fixed title of the project in the documentation by updating to use a `Documenteer <https://documenteer.lsst.io>`_\ -based Sphinx set up.
+- Fixed a bug where ``ltdconveyor.s3.delete_dir`` would fail if there are more than 1000 objects under a path prefix that is being deleted.
+- Fixed title of the project in the documentation by updating to use a `Documenteer`_\ -based Sphinx set up.
 
 0.4.0 (2018-04-17)
 ==================
@@ -117,7 +125,7 @@ Added
 .. _LTD Keeper: https://ltd-keeper.lsst.io
 .. _LTD Mason: https://ltd-mason.lsst.io
 .. _LTD Dasher: https://github.com/lsst-sqre/ltd-dasher
-.. _Documenteer: https://github.com/lsst-sqre/documenteer
+.. _Documenteer: https://documenteer.lsst.io
 .. _Click: http://click.pocoo.org/
 .. _sphinx-click: https://sphinx-click.readthedocs.io/en/latest/
 .. _LSST Science Pipelines: https://pipelines.lsst.io

--- a/ltdconveyor/s3/delete.py
+++ b/ltdconveyor/s3/delete.py
@@ -53,7 +53,10 @@ def delete_dir(bucket_name, root_path,
 
     keys = dict(Objects=[])
     for item in pages.search('Contents'):
-        keys['Objects'].append({'Key': item['Key']})
+        try:
+            keys['Objects'].append({'Key': item['Key']})
+        except TypeError:  # item is None; nothing to delete
+            continue
         # Delete immediately when 1000 objects are listed
         # the delete_objects method can only take a maximum of 1000 keys
         if len(keys['Objects']) >= 1000:
@@ -66,7 +69,7 @@ def delete_dir(bucket_name, root_path,
             keys = dict(Objects=[])
 
     # Delete remaining keys
-    if len(keys['Objects']):
+    if len(keys['Objects']) > 0:
         try:
             client.delete_objects(Bucket=bucket_name, Delete=keys)
         except Exception:

--- a/tests/test_s3delete.py
+++ b/tests/test_s3delete.py
@@ -75,3 +75,9 @@ def test_delete_dir(request):
             assert bucket_path not in bucket_paths
         else:
             assert bucket_path in bucket_paths
+
+    # Attempt to delete an empty prefix. Ensure it does not raise an exception.
+    delete_dir(os.getenv('LTD_TEST_BUCKET'),
+               bucket_root + 'empty-prefix/',
+               os.getenv('LTD_TEST_AWS_ID'),
+               os.getenv('LTD_TEST_AWS_SECRET'))


### PR DESCRIPTION
`delete_dir` would fail if attempting to delete objects in a prefix where there aren't any objects. Now we gracefully handle that case.

There's also a new test to exercise this case.