### PR TITLE
DM-23333: Make setuptools_scm backwards compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.5
 packages = find:
+setup_requires =
+  setuptools_scm
 install_requires =
     boto3==1.4.4
     requests>=2.12.4

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
 
 
-setup()
+setup(
+    use_scm_version=True
+)


### PR DESCRIPTION
`python setup.py sdist` was not picking up setuptools_scm in Travis CI.