### PR TITLE
DM-23591: Add support for uploads from GitHub Actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+0.6.0 (2020-02-20)
+==================
+
+Added
+-----
+
+- Added a ``--gh`` option to the ``ltd upload`` command to support usage in `GitHub Actions <https://help.github.com/en/actions>`__.
+
 0.5.0 (2020-02-05)
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Key features:
 
 - :doc:`ltd <cli>` command-line app.
 
-  The :program:`ltd upload` subcommand makes it easy to integrate documentation uploads with continuous integration jobs, particularly Travis CI.
+  The :program:`ltd upload` subcommand makes it easy to integrate documentation uploads with continuous integration jobs, particularly GitHub Actions and Travis CI.
 
 - The `ltdconveyor` Python package provides APIs for working with LSST the Docs.
 


### PR DESCRIPTION
This adds a `--gh` option to the `ltd upload` command to support usage in [GitHub Actions](https://help.github.com/en/actions).