### PR TITLE
DM-23591: Support tags and PRs with --gh option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+0.6.1 (2020-02-23)
+==================
+
+Fixed
+-----
+
+- The ``--gh`` option for ``ltd upload`` now supports tag and PR events, in addition to branches.
+
 0.6.0 (2020-02-20)
 ==================
 

--- a/ltdconveyor/cli/upload.py
+++ b/ltdconveyor/cli/upload.py
@@ -200,7 +200,7 @@ def _get_gh_actions_git_refs():
             'Using --gh but the GITHUB_REF environment variable is '
             'not detected.')
     match = re.match(
-        r"refs/heads/(?P<ref>.+)",
+        r"refs/(heads|tags|pull)/(?P<ref>.+)",
         github_ref
     )
     if not match:

--- a/tests/test_cli_upload.py
+++ b/tests/test_cli_upload.py
@@ -80,6 +80,8 @@ def test_get_gh_actions_git_refs_no_env_var(monkeypatch):
         ('my_branch', 'travis', 'user-branch', ['user-branch']),
         # using GitHub actions branch
         ('refs/heads/my_branch', 'gh', None, ['my_branch']),
+        ('refs/tags/my_tag', 'gh', None, ['my_tag']),
+        ('refs/pull/my_pr', 'gh', None, ['my_pr']),
         # overriding GitHub actions on command line
         ('refs/heads/my_branch', 'gh', 'user-branch', ['user-branch']),
         # only using command line arg


### PR DESCRIPTION
Like `refs/heads/branchname`, this adds support for `refs/tags/tagname` and `refs/pull/prname` for the `ltd upload --gh` option.