### PR TITLE
Improve development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,5 @@
 init:
 	pip install -e ".[dev]"
 	pip install --upgrade tox tox-pyenv pre-commit
+	rm -rf .tox
 	pre-commit install

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ setup_requires =
   setuptools_scm
 install_requires =
     boto3
+    docutils<0.16,>=0.10  # to boto3 with sphinx
     requests
     uritemplate
     click
@@ -54,7 +55,7 @@ dev =
     documenteer[pipelines]
     sphinx-click
     coverage[toml]
-    Sphinx<2.0  # compatible with documenteer < 0.6 and its automodapi
+    Sphinx
     mypy
 
 [options.entry_points]


### PR DESCRIPTION
- Pin docutils <0.16 because botocore in runtime dependencies requires docutils<0.16,>=0.10, but the docutils version was being driven somehow by sphinx in the `[dev]` extra. This pinning patches that issue.
- `make init` clears the existing `.tox` directory.