### PR TITLE
DM-31791: Add compatibility with pull_request-based events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.8.0 (2021-09-15)
+==================
+
+The ``ltd upload`` command now works in pull requests workflows on GitHub Actions.
+
 0.7.0 (2020-09-01)
 ==================
 

--- a/src/ltdconveyor/cli/upload.py
+++ b/src/ltdconveyor/cli/upload.py
@@ -224,7 +224,11 @@ def _get_travis_git_refs() -> List[str]:
 
 
 def _get_gh_actions_git_refs() -> List[str]:
-    github_ref = os.getenv("GITHUB_REF", "")
+    if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        ref_env_var = "GITHUB_HEAD_REF"
+    else:
+        ref_env_var = "GITHUB_REF"
+    github_ref = os.getenv(ref_env_var, "")
     if github_ref == "":
         raise click.UsageError(
             "Using --gh but the GITHUB_REF environment variable is "


### PR DESCRIPTION
In a pull_request GitHub Actions event, we need to use the `GITHUB_HEAD_REF` variable, instead of `GITHUB_REF`, to get the name of the branch that triggered the pull request.