### PR TITLE
DM-31908: Fix uploads from PR-triggered workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.8.1 (2021-09-27)
+==================
+
+Fix parsing of the ``GITHUB_HEAD_REF`` environment variable in GitHub Actions.
+
 0.8.0 (2021-09-15)
 ==================
 

--- a/src/ltdconveyor/cli/upload.py
+++ b/src/ltdconveyor/cli/upload.py
@@ -225,10 +225,23 @@ def _get_travis_git_refs() -> List[str]:
 
 def _get_gh_actions_git_refs() -> List[str]:
     if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
-        ref_env_var = "GITHUB_HEAD_REF"
+        return [_match_pr_head_ref()]
     else:
-        ref_env_var = "GITHUB_REF"
-    github_ref = os.getenv(ref_env_var, "")
+        return [_match_github_ref()]
+
+
+def _match_pr_head_ref() -> str:
+    github_ref = os.getenv("GITHUB_HEAD_REF", "")
+    if github_ref == "":
+        raise click.UsageError(
+            "Using --gh but the GITHUB_HEAD_REF environment variable is "
+            "not detected."
+        )
+    return github_ref
+
+
+def _match_github_ref() -> str:
+    github_ref = os.getenv("GITHUB_REF", "")
     if github_ref == "":
         raise click.UsageError(
             "Using --gh but the GITHUB_REF environment variable is "
@@ -242,4 +255,4 @@ def _get_gh_actions_git_refs() -> List[str]:
             )
         )
     ref = match.group("ref")
-    return [ref]
+    return ref


### PR DESCRIPTION
Fix uploads from PR-triggered workflows. The `GITHUB_HEAD_REF` variable is not prefixed with `refs/heads/`, as the `GITHUB_REF` variable is.