### PR TITLE
DM-42977: Adopt importlib_metadata for 0.8 releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,11 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.7
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install tox and
         run: |
@@ -78,7 +80,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,50 +16,49 @@ jobs:
           - "3.12"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install tox
-        run: pip install tox
-
       - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "lint,typing,py"
         env:
           LTD_TEST_AWS_ID: ${{ secrets.LTD_TEST_AWS_ID }}
           LTD_TEST_AWS_SECRET: ${{ secrets.LTD_TEST_AWS_SECRET }}
           LTD_TEST_BUCKET: ${{ secrets.LTD_TEST_BUCKET }}
-        run: tox -e py,lint,typing  # run tox using Python in path
 
   docs:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
-      - name: Install tox and
-        run: |
-          pip install tox
-
       - name: Run tox
-        run: tox -e docs
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "docs"
 
       - name: Install LTD Conveyor for upload
         run: pip install .
 
-      - name: Upload to LSST the Docs
+      - name: Upload to LSST the docs
         if: ${{ github.event_name == 'push' }}
         env:
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
@@ -68,29 +67,22 @@ jobs:
 
   pypi:
 
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
     needs: [test, docs]
     if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ltd-conveyor
+    permissions:
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full depth for setuptools_scm
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine
-
       - name: Build and publish
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.PYPI_SQRE_ADMIN }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
+        with:
+          python-version: "3.11"

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -21,24 +21,24 @@ jobs:
           - "3.12"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install tox
-        run: pip install tox
-
       - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "lint,typing,py"
         env:
           LTD_TEST_AWS_ID: ${{ secrets.LTD_TEST_AWS_ID }}
           LTD_TEST_AWS_SECRET: ${{ secrets.LTD_TEST_AWS_SECRET }}
           LTD_TEST_BUCKET: ${{ secrets.LTD_TEST_BUCKET }}
-        run: tox -e py,lint,typing  # run tox using Python in path
 
   docs:
 
@@ -50,13 +50,12 @@ jobs:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
-      - name: Install tox and LTD Conveyor
-        run: |
-          pip install tox
-
       - name: Run tox
-        run: tox -e docs
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "docs"

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -14,9 +14,11 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.7
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install tox and LTD Conveyor
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Byte-compiled / optimized / DLL files
-__pycache__/
+__pycache__
 *.py[cod]
 *$py.class
 
@@ -82,6 +82,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -9,25 +9,25 @@ repos:
       - id: check-json
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 24.2.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.10.0
+    rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==20.8b1]
+        additional_dependencies: [black]
         args: [-l, '79', -t, py38]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
     hooks:
       - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.8.2 (2024-02-22)
+==================
+
+- Removed usage of ``pkg_resources`` for better compatibility with Python 3.12 environments.
+- Fixed internal typing issues.
+- Updated the GitHub Actions workflows.
+
 0.8.1 (2021-09-27)
 ==================
 
@@ -10,7 +17,7 @@ Fix parsing of the ``GITHUB_HEAD_REF`` environment variable in GitHub Actions.
 0.8.0 (2021-09-15)
 ==================
 
-The ``ltd upload`` command now works in pull requests workflows on GitHub Actions.
+The ``ltd upload`` command now works in pull request workflows on GitHub Actions.
 
 0.7.0 (2020-09-01)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     requests
     uritemplate
     click
+    importlib-metadata
 
 [options.packages.find]
 where = src

--- a/src/ltdconveyor/__init__.py
+++ b/src/ltdconveyor/__init__.py
@@ -2,7 +2,7 @@ __all__ = ("s3", "fastly", "ConveyorError")
 
 import logging
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib_metadata import PackageNotFoundError, version
 
 from . import fastly, s3
 from .exceptions import ConveyorError
@@ -11,7 +11,7 @@ from .exceptions import ConveyorError
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
-    __version__ = get_distribution("ltd-conveyor").version
-except DistributionNotFound:
+    __version__ = version("ltd-conveyor")
+except PackageNotFoundError:
     # Package is not installed
     __version__ = "unknown"

--- a/src/ltdconveyor/s3/presignedpost.py
+++ b/src/ltdconveyor/s3/presignedpost.py
@@ -91,7 +91,10 @@ def format_relative_dirname(directory: Path, base_directory: Path) -> str:
 
 
 def upload_dir(
-    *, post_urls: Dict[str, Any], base_dir: Path, _current_dir: Path = None
+    *,
+    post_urls: Dict[str, Any],
+    base_dir: Path,
+    _current_dir: Optional[Path] = None,
 ) -> None:
     """Upload a local directory of files to S3 for an LSST the Docs build.
 

--- a/src/ltdconveyor/s3/upload.py
+++ b/src/ltdconveyor/s3/upload.py
@@ -133,7 +133,7 @@ def upload_dir(
 
     manager = ObjectManager(session, bucket_name, path_prefix)
 
-    for (rootdir, dirnames, filenames) in os.walk(source_dir):
+    for rootdir, dirnames, filenames in os.walk(source_dir):
         # name of root directory on S3 bucket
         bucket_root = os.path.relpath(rootdir, start=source_dir)
         if bucket_root in (".", "/"):


### PR DESCRIPTION
By dropping use of `pkg_resources` we no longer have a runtime dependency on `setuptools`. This will be released as 0.8.2.