### PR TITLE
DM-46703: Add setuptools runtime dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     uritemplate
     click
     importlib-metadata
+    setuptools
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
A dependency of ltd-conveyor seems to have an undeclared runtime dependency on setuptools. In Python 3.12, packages must declare a setuptools dependency to ensure its installed.