### PR TITLE
`#dm-docs-support` -> `#square-docs-support`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "py,typing"
         env:
-          LTD_TEST_AWS_ID: ${{ secrets.LTD_TEST_AWS_ID }}
+          LTD_TEST_AWS_ID: ${{ vars.LTD_TEST_AWS_ID }}
           LTD_TEST_AWS_SECRET: ${{ secrets.LTD_TEST_AWS_SECRET }}
-          LTD_TEST_BUCKET: ${{ secrets.LTD_TEST_BUCKET }}
+          LTD_TEST_BUCKET: ${{ vars.LTD_TEST_BUCKET }}
 
   docs:
 

--- a/changelog.d/20241118_133228_danfuchs_DM_47580.md
+++ b/changelog.d/20241118_133228_danfuchs_DM_47580.md
@@ -1,4 +1,3 @@
 ### Bug fixes
 
 - Change Slack channel references to refer to channels in the Rubin Slack instance.
-- Get non-sensitive CI vars from GitHub variables instead of secrets

--- a/changelog.d/20241118_133228_danfuchs_DM_47580.md
+++ b/changelog.d/20241118_133228_danfuchs_DM_47580.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Change Slack channel references to refer to channels in the Rubin Slack instance.

--- a/changelog.d/20241118_133228_danfuchs_DM_47580.md
+++ b/changelog.d/20241118_133228_danfuchs_DM_47580.md
@@ -1,3 +1,4 @@
 ### Bug fixes
 
 - Change Slack channel references to refer to channels in the Rubin Slack instance.
+- Get non-sensitive CI vars from GitHub variables instead of secrets

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -29,3 +29,13 @@ Releases are made by creating a Git tag with a semantic version and pushing to G
    git push --tags
 
 Travis CI creates the PyPI release itself and `setuptools_scm <https://github.com/pypa/setuptools_scm/>`_ ensures the PyPI version matches the Git tag.
+
+GitHub CI
+=========
+
+The GitHub CI action needs AWS creds and an existing S3 bucket.
+These creds and the bucket name are injected via repository-scoped Actions `secrets <https://github.com/lsst-sqre/ltd-conveyor/settings/secrets/actions>`_ and `variables <https://github.com/lsst-sqre/ltd-conveyor/settings/variables/actions>`_
+
+These creds are attached to the `ltd-conveyor-tests IAM user <https://us-east-1.console.aws.amazon.com/iam/home?region=us-west-2#/users/details/ltd-conveyor-tests?section=permissions>`_.
+This user has an attached `ltd-conveyor-tests policy <https://us-east-1.console.aws.amazon.com/iam/home?region=us-west-2#/policies/details/arn%3Aaws%3Aiam%3A%3A039289279626%3Apolicy%2Fltd-conveyor-tests?section=permissions>`_.
+This policy grants access to the `lsst-the-docs-test S3 bucket <https://us-west-2.console.aws.amazon.com/s3/buckets/lsst-the-docs-test?region=us-west-2&bucketType=general&tab=objects>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "coverage[toml]",
     "mypy",
     "types-requests",
-    "types-pkg_resources",
+    "types-setuptools",
     # Documentation
     "documenteer[guide]",
     "sphinx-click",

--- a/src/ltdconveyor/keeper/v1/build.py
+++ b/src/ltdconveyor/keeper/v1/build.py
@@ -123,7 +123,7 @@ def register_build(
             raise KeeperError(
                 f"Could not register a new build for the project {product}. "
                 "It's possible that the project is not registered yet. Please "
-                "contact #dm-docs-support on Slack.",
+                "contact #square-docs-support on Slack.",
                 r2.status_code,
                 r2.text,
             )
@@ -132,7 +132,7 @@ def register_build(
             f"Could not register a new build for the project {product}. "
             "It's possible that another build is currently underway. Please "
             "re-run the documentation job in a few minutes. If the problem "
-            "persists, contact #dm-docs-support on Slack.",
+            "persists, contact #square-docs-support on Slack.",
             r.status_code,
             r.text,
         )
@@ -166,7 +166,7 @@ def confirm_build(build_url: str, keeper_token: str) -> None:
     if r.status_code != 200:
         raise KeeperError(
             f"Could not confirm build upload for {build_url}. "
-            "Contact #dm-docs-support on Slack",
+            "Contact #square-docs-support on Slack",
             r.status_code,
             r.text,
         )


### PR DESCRIPTION
Also, this build had rotted a bit, so I did some stuff to fix it:
* The `types-pkg_resources package` has been yanked from pypi.  I replaced it with the `types-setuptools` package.
* The GitHub CI job needs AWS creds, it was using creds attached to Jonathan’s human IAM user. I made a new IAM user with access only to the `lsst-the-docs-test` S3 bucket.
* Changed the `LTD_TEST_AWS_ID` and `LTD_TEST_BUCKET` GitHub repo secrets into variables so that repo admins can see their values (`LTD_TEST_AWS_SECRET` remains a secret).
* Generated an access key for the new user and put the creds in the GitHub vars/secrets.
* Documented the GitHub CI / AWS integration.