### PR TITLE
DM-47580: remove `types-setuptools` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dev = [
     "coverage[toml]",
     "mypy",
     "types-requests",
-    "types-setuptools",
     # Documentation
     "documenteer[guide]",
     "sphinx-click",
@@ -76,10 +75,6 @@ include = ["ltdconveyor*"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
-filterwarnings = [
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
-]
 python_files = [
     "tests/*.py",
     "tests/*/*.py"


### PR DESCRIPTION
...and associated warnings. We don't use it anymore.

[Good catch](https://github.com/lsst-sqre/ltd-conveyor/pull/70#issuecomment-2486605764) @timj !